### PR TITLE
Updates for the Trainline

### DIFF
--- a/lib/eventmachine/circuit_breaker/breaker.rb
+++ b/lib/eventmachine/circuit_breaker/breaker.rb
@@ -6,13 +6,21 @@ module EventMachine
       end
 
       def request(client, headers, body)
-        close!(client) if strategy.open?
+        close!(client) if strategy.open?(client)
         [headers, body]
       end
 
       def response(client)
         strategy.handle_response(client)
-        close!(client) if strategy.open?
+        close!(client) if strategy.open?(client)
+      end
+
+      def status_report
+        strategy.status_report
+      end
+
+      def open!
+        strategy.open!
       end
 
       private

--- a/lib/eventmachine/circuit_breaker/strategy/basic.rb
+++ b/lib/eventmachine/circuit_breaker/strategy/basic.rb
@@ -2,49 +2,159 @@ module EventMachine
   module CircuitBreaker
     module Strategy
       class Basic
-        def initialize(failure_count: 5, recovery_time: 30)
+        def initialize(failure_limit: 5, recovery_time: 30, recovery_ratio: 0.1, log_proc: nil)
           @mutex = EventMachine::CircuitBreaker::RWMutex.new
-          close!
-          @failure_limit = failure_count
           @recovery_time = recovery_time
+          @state = State.new(
+            :failure_limit  => failure_limit,
+            :recovery_ratio => recovery_ratio,
+            :log_proc       => log_proc || method(:log),
+            :on_open        => method(:on_open),
+          )
         end
 
-        def open?
-          mutex.read_lock { @state == :open }
+        def open?(_client = nil)
+          mutex.read_lock { @state.open? }
         end
 
         def handle_response(client)
-          increment_failures if client.response_header.server_error?
-          close! if half_open? && client.response_header.successful?
+          err = client.response_header.server_error?
+
+          mutex.write_lock do
+            @state.client = client
+            err ? @state.handle_failure : @state.handle_success
+          end
+        end
+
+        def status_report
+          {
+            :status => open? ? "OPEN" : "CLOSED",
+          }
+        end
+
+        def open!
+          mutex.write_lock { @state.open! }
         end
 
         private
 
         attr_reader :mutex
 
-        def half_open?
-          mutex.read_lock { @state == :half_open }
+        # Callback for state - called after the circuit breaker is opened
+        def on_open
+          log(
+            :level   => :info,
+            :message => "Will set circuit to half-open in #{@recovery_time} seconds",
+          )
+          EventMachine.add_timer(@recovery_time) do
+            mutex.write_lock { @state.handle_recovery_timer }
+          end
         end
 
-        def increment_failures
-          mutex.write_lock { @failures += 1 }
-          open! if mutex.read_lock { @failures >= @failure_limit }
+        def log(level: :info, client: nil, message: '')
+          request = client&.req
+          host = request&.host || nil
+          path = request&.path || nil
+
+          puts "#{level.to_s.upcase}: Circuit breaker[#{host}][#{path}]\n\t#{message}"
         end
 
-        def half_open!
-          mutex.write_lock { @state = :half_open }
-        end
+        class State
+          attr_reader :log_proc
+          attr_accessor :client
 
-        def open!
-          mutex.write_lock { @state = :open }
+          def initialize(failure_limit:, recovery_ratio:, log_proc: nil, on_open: nil)
+            @failure_limit = failure_limit
+            @recovery_ratio = recovery_ratio
+            @log_proc = log_proc
+            @on_open = on_open
 
-          EventMachine.add_timer(@recovery_time) { half_open! }
-        end
-
-        def close!
-          mutex.write_lock do
             @state = :closed
             @failures = 0
+          end
+
+          # Circuit Closed - default state - all good
+          def closed?
+            @state == :closed
+          end
+
+          # Circuit Open - there were too many failures, rejecting all requests for a while
+          def open?
+            @state == :open
+          end
+
+          # Circuit was open, giving it a chance to recover
+          def half_open?
+            @state == :half_open
+          end
+
+          def close!
+            @state = :closed
+            @failures = 0
+            log(
+              :level   => :info,
+              :message => "Closed. Failure count: #{@failures}",
+            )
+          end
+
+          def open!
+            return if open?
+            @state = :open
+            log(
+              :level   => :error,
+              :message => "Opening circuit!",
+            )
+            @on_open.call if @on_open.present?
+          end
+
+          def half_open!
+            @state = :half_open
+            log(
+              :level   => :info,
+              :message => "Half-open",
+            )
+          end
+
+          def handle_failure
+            increment_failure_counter
+          end
+
+          def increment_failure_counter
+            @failures += 1
+            log(
+              :level   => :warn,
+              :message => "Failure. Counter: #{@failures.round(2)}",
+            )
+            open! if @failures >= @failure_limit
+          end
+
+          def handle_success
+            decrement_failure_counter
+            close! if half_open?
+          end
+
+          def decrement_failure_counter
+            if @failures > 0
+              @failures -= @recovery_ratio
+              log(
+                :level   => :info,
+                :message => "Success. Counter: #{@failures.round(2)}",
+              )
+            end
+          end
+
+          def handle_recovery_timer
+            half_open!
+          end
+
+          def log(level:, message:)
+            if @log_proc.present?
+              @log_proc.call(
+                :level   => level,
+                :client  => client,
+                :message => message,
+              )
+            end
           end
         end
       end

--- a/lib/eventmachine/circuit_breaker/strategy/basic.rb
+++ b/lib/eventmachine/circuit_breaker/strategy/basic.rb
@@ -104,7 +104,7 @@ module EventMachine
               :level   => :error,
               :message => "Opening circuit!",
             )
-            @on_open.call if @on_open.present?
+            @on_open.call if @on_open
           end
 
           def half_open!
@@ -148,7 +148,7 @@ module EventMachine
           end
 
           def log(level:, message:)
-            if @log_proc.present?
+            if @log_proc
               @log_proc.call(
                 :level   => level,
                 :client  => client,

--- a/lib/eventmachine/circuit_breaker/version.rb
+++ b/lib/eventmachine/circuit_breaker/version.rb
@@ -1,5 +1,5 @@
 module EventMachine
   module CircuitBreaker
-    VERSION = "0.1.2"
+    VERSION = "0.2.0"
   end
 end

--- a/test/eventmachine/circuit_breaker/breaker_test.rb
+++ b/test/eventmachine/circuit_breaker/breaker_test.rb
@@ -14,7 +14,7 @@ module EventMachine
           @responses = []
         end
 
-        def open?
+        def open?(_client)
           state == :open
         end
 

--- a/test/eventmachine/circuit_breaker/strategy/basic_test.rb
+++ b/test/eventmachine/circuit_breaker/strategy/basic_test.rb
@@ -22,7 +22,7 @@ module EventMachine
 
         def test_closes_after_configured_failures
           within_eventmachine do |done|
-            strategy = Basic.new(failure_count: 2)
+            strategy = Basic.new(failure_limit: 2)
             multi = EventMachine::MultiRequest.new
 
             callback(multi, done) do
@@ -40,7 +40,7 @@ module EventMachine
 
         def test_recovers_after_configured_time
           within_eventmachine do |done|
-            strategy = Basic.new(failure_count: 1, recovery_time: 0.2)
+            strategy = Basic.new(failure_limit: 1, recovery_time: 0.2)
 
             http_req(:get, "http://example.com/fail", strategy) do |client|
               callback(client, done, flunk: true)
@@ -64,7 +64,7 @@ module EventMachine
 
         def test_allows_single_request_to_test_recovery_fail
           within_eventmachine do |done|
-            strategy = Basic.new(failure_count: 1, recovery_time: 0.1)
+            strategy = Basic.new(failure_limit: 1, recovery_time: 0.1)
 
             http_req(:get, "http://example.com/fail", strategy) do |client|
               callback(client, done, flunk: true)
@@ -89,7 +89,7 @@ module EventMachine
 
         def test_allows_single_request_to_test_recovery_success
           within_eventmachine do |done|
-            strategy = Basic.new(failure_count: 1, recovery_time: 0.1)
+            strategy = Basic.new(failure_limit: 1, recovery_time: 0.1)
 
             http_req(:get, "http://example.com/fail", strategy) do |client|
               callback(client, done, flunk: true)


### PR DESCRIPTION
- added recovery_ratio for unwinding after service returns to normal ( kind of solves https://github.com/dcoxall/eventmachine-circuit_breaker/issues/4 )
- added log_proc to inject logging rules
- updated open? method signature to allow for passing the client
- extracted internal state into its own object
- added status_report to strategies
- added open! method for testing purposes